### PR TITLE
SQL generation: update logic based on input change

### DIFF
--- a/__tests__/sqlController.js
+++ b/__tests__/sqlController.js
@@ -2,19 +2,107 @@ const { composeSqlQuery } = require('../server/controllers/sqlController');
 
 describe('SQL Query generation unit tests', () => {
     // TODO: Unique, not null
-    const sampleInput = {
-        table1Name: {
-            column1Name: { primaryKey: true, type: 'varchar' },
-            column2Name: 'varchar',
-            column3Name: 'float',
-            column4Name: 'boolean',
-            column5Name: { linkedTable: 'table2Name' }
+    const sampleInput = [
+        {
+            "table": "people",
+            "columns": [
+                {
+                    "_id": {
+                        "primaryKey": true,
+                        "type": "SERIAL"
+                    }
+                },
+                {
+                    "name": "VARCHAR(255)"
+                },
+                {
+                    "mass": "FLOAT"
+                },
+                {
+                    "hair_color": "VARCHAR(255)"
+                },
+                {
+                    "skin_color": "VARCHAR(255)"
+                },
+                {
+                    "eye_color": "VARCHAR(255)"
+                },
+                {
+                    "birth_year": "VARCHAR(255)"
+                },
+                {
+                    "gender": "VARCHAR(255)"
+                },
+                {
+                    "height": "INT"
+                },
+                {
+                    "column5Name": {
+                        "linkedTable": 'species._id',
+                        "type": 'SERIAL',
+                    }
+                }
+            ]
         },
-        table2Name: {
-            column1Name: { primaryKey: true, type: 'integer' },
-            column2Name: 'varchar'
+        {
+            "table": "species",
+            "columns": [
+                {
+                    "_id": {
+                        "primaryKey": true,
+                        "type": "SERIAL"
+                    }
+                },
+                {
+                    "name": "VARCHAR(255)"
+                },
+                {
+                    "classification": "VARCHAR(255)"
+                },
+                {
+                    "average_height": "VARCHAR(255)"
+                },
+                {
+                    "average_lifespan": "VARCHAR(255)"
+                },
+                {
+                    "hair_colors": "VARCHAR(255)"
+                },
+                {
+                    "skin_colors": "VARCHAR(255)"
+                },
+                {
+                    "eye_colors": "VARCHAR(255)"
+                },
+                {
+                    "language": "VARCHAR(255)"
+                }
+            ]
+        },
+        {
+            "table": "films",
+            "columns": [
+                {
+                    "_id": {
+                        "primaryKey": true,
+                        "type": "SERIAL"
+                    }
+                },
+                {
+                    "title": "VARCHAR(255)"
+                },
+                {
+                    "director": "VARCHAR(255)"
+                },
+                {
+                    "producer": "VARCHAR(255)"
+                },
+                {
+                    "release_date": "DATE"
+                }
+            ]
         }
-    };
+    ];
 
     it('generates query', () => {
         // TODO: add expects

--- a/server/controllers/sqlController.js
+++ b/server/controllers/sqlController.js
@@ -1,20 +1,3 @@
-/**
- * Draft expected input:
-  {
-    table1Name: {
-      column1Name: {primaryKey: true, type: “number”},
-      column2Name: “string”,
-      column3Name: “number”,
-      column4Name: “boolean”,
-      column5Name: {linkedTable: table2Name.column1Name, type: “number”}
-    },
-    table2Name: {
-      column1Name: {primaryKey: true, type: “number”},
-      column2Name: “string”
-    }
-  }
- */
-
 const util = require('util');
 const sqlController = {};
 
@@ -26,48 +9,25 @@ const sqlController = {};
  *   NAME VARCHAR(255) NOT NULL
  * );
  */
-const composeSqlQuery = (json) => {
+// See __tests__/sqlController.js for expected input
+const composeSqlQuery = (input) => {
     const outputArray = [];
     const TAB = '\t';
-    Object.keys(json).forEach(entity => {
-        let query = `CREATE TABLE ID NOT EXISTS ${entity} (\n%s);`
-        let tableStringArray = [`_id SERIAL PRIMARY KEY`];
-        const attrObj = json[entity];
-        Object.keys(attrObj).forEach(attribute => {
-            const value = attrObj[attribute];
+    input.forEach(({ table, columns }) => {
+        let query = `CREATE TABLE IF NOT EXISTS ${table} (\n%s);`
+        let tableStringArray = [];
+        columns.forEach(column => {
+            // TODO: Validate that keys have only one element
+            const tableName = Object.keys(column)[0];
+            const value = column[tableName];
             if (typeof value === 'object' && value.hasOwnProperty('linkedTable')) {
-                const tableName = value['linkedTable'];
-                tableStringArray.push(`${tableName}_id INT REFERENCES ${tableName}(_id)`);
+                // TODO: validate only one element in output
+                const referencedTable = value['linkedTable'].split(".")[0];
+                tableStringArray.push(`${referencedTable}_id INT REFERENCES ${referencedTable}(_id)`);
+            } else if (typeof value === 'object' && value.hasOwnProperty('primaryKey')) {
+                tableStringArray.push(`${tableName} ${value.type} PRIMARY KEY`);
             } else {
-                const substringArray = [attribute];
-                const type = typeof attrObj[attribute] === 'string' ?
-                    attrObj[attribute] : attrObj[attribute]['type'];
-                switch (type) {
-                    // TODO: Potentially set these as types
-                    case 'varchar': {
-                        substringArray.push('VARCHAR(255)');
-                        break;
-                    }
-                    case 'integer': {
-                        substringArray.push('INT');
-                        break
-                    }
-                    case 'float': {
-                        substringArray.push('FLOAT');
-                        break;
-                    }
-                    case 'boolean': {
-                        substringArray.push('BOOLEAN');
-                        break;
-                    }
-                    // TODO: date or timestamp (TIMESTAMPTZ)?
-                    case 'date': {
-                        substringArray.push('DATE');
-                        break;
-                    }
-                    default: throw new Error(`Unexpected data type: ${type}.`)
-                }
-                tableStringArray.push(substringArray.join(' '));
+                tableStringArray.push(`${tableName} ${value}`);
             }
         }
         );


### PR DESCRIPTION
Update logic to accommodate the new version of the input

Note that this changes only contain backend changes and I will address connecting the front and back end in a separate PR.

**NOTE TO REVIEWER: Please do not merge for me upon approval. Thank you.**

Test result:
```
➜  ExcQL git:(sql) ✗ npm test

> excql@1.0.0 test
> NODE_ENV=test jest

  console.log
    CREATE TABLE IF NOT EXISTS people (
        _id SERIAL PRIMARY KEY
        name VARCHAR(255)
        mass FLOAT
        hair_color VARCHAR(255)
        skin_color VARCHAR(255)
        eye_color VARCHAR(255)
        birth_year VARCHAR(255)
        gender VARCHAR(255)
        height INT
        species_id INT REFERENCES species(_id)
    );
    
    CREATE TABLE IF NOT EXISTS species (
        _id SERIAL PRIMARY KEY
        name VARCHAR(255)
        classification VARCHAR(255)
        average_height VARCHAR(255)
        average_lifespan VARCHAR(255)
        hair_colors VARCHAR(255)
        skin_colors VARCHAR(255)
        eye_colors VARCHAR(255)
        language VARCHAR(255)
    );
    
    CREATE TABLE IF NOT EXISTS films (
        _id SERIAL PRIMARY KEY
        title VARCHAR(255)
        director VARCHAR(255)
        producer VARCHAR(255)
        release_date DATE
    );

      at Object.log (__tests__/sqlController.js:109:17)

 PASS  __tests__/sqlController.js
  SQL Query generation unit tests
    ✓ generates query (11 ms)

------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   78.57 |      100 |      50 |   78.57 |                   
 sqlController.js |   78.57 |      100 |      50 |   78.57 | 41-52             
------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        0.222 s, estimated 1 s
Ran all test suites.
```