### PR TITLE
Info Panel: Add column/table mapping to POST request

### DIFF
--- a/client/components/Info Panel/InfoPanel.css
+++ b/client/components/Info Panel/InfoPanel.css
@@ -83,7 +83,7 @@ input[type='file'] {
 }
 
 .info-panel__error {
-  margin-top: 2rem;
+  margin-top: 1.5rem;
   font-size: 1.8rem;
   text-align: center;
   font-weight: bold;

--- a/client/components/Info Panel/InfoPanel.js
+++ b/client/components/Info Panel/InfoPanel.js
@@ -20,8 +20,8 @@ const InfoPanel = () => {
   const uploadExcelHandler = async (e) => {
     try {
       e.preventDefault();
-
       const files = e.target.files.files;
+      if (files.length === 0) throw new Error('No file uploaded.')
       const excelFile = new FormData();
       excelFile.append('excel', files[0]);
 
@@ -49,6 +49,7 @@ const InfoPanel = () => {
       );
       const data = await response.json();
       console.log(data);
+      if (uploadError) setUploadError(false);
     } catch (error) {
       console.error(error);
       setUploadError(true);
@@ -118,17 +119,19 @@ const InfoPanel = () => {
         <span className="info-panel__steps">
           Step 3: Upload the file and watch magic happen!
         </span>
+        <div>
+          {uploadError && (
+            <p className="info-panel__error">
+              Uh oh! 😭 Upload failed. Please try again.
+            </p>
+          )}
+        </div>
         <div className="upload-form--container">
           <button type="submit" className="info-panel__upload-btn">
             Upload!
           </button>
         </div>
       </form>
-      {uploadError && (
-        <p className="info-panel__error">
-          Uh oh! 😭 Upload failed. Please try again.
-        </p>
-      )}
     </section>
   );
 };

--- a/client/components/Info Panel/InfoPanel.js
+++ b/client/components/Info Panel/InfoPanel.js
@@ -121,8 +121,8 @@ const MappingInput = (props) => {
   const { id, handleInputChange } = props;
   return (
     <div className='input-container'>
-      <input id={id} name='fileColumn' type='text' onChange={handleInputChange} />
-      <input id={id} name='tableName' type='text' onChange={handleInputChange} />
+      <input id={id} name='fileColumn' type='text' onChange={handleInputChange} required={id === 0} />
+      <input id={id} name='tableName' type='text' onChange={handleInputChange} required={id === 0} />
     </div>
   );
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Mynerve&display=swap" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Neuton:wght@300;400&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Neuton:wght@300;400;700&display=swap" rel="stylesheet" />
 
   <title>ExcQL</title>
 </head>


### PR DESCRIPTION
- Make the first column/table mapping input required so that we do not send the excel to the backend without at least one set of mapping
- Add column/table mapping to POST request so the backend can use the mapping to determine the number of tables and where the content of the tables would be
- Add more instructions to indicate the mapping is assumed from left to right of the file. Enforce the mapping in the POST request is ordered by column letter
- If the user did not upload a file, show the error message. If subsequent retries are successful, remove the error message accordingly.